### PR TITLE
Fix missing checks from TMs mode

### DIFF
--- a/locations/DarkCaveBlackthornSide.json
+++ b/locations/DarkCaveBlackthornSide.json
@@ -10,7 +10,15 @@
 				"access_rules": ["@Ecruteak City, @canUseStrength, $canFightTeamRocket, @canUseSurf"],
 				"visibility_rules": ["full_item"],
 				"clear_as_group": false,
-				"item_count": 2
+				"item_count": 1
+			},
+			{
+				"name": "TM13 - Snore",
+				"access_rules": ["@Ecruteak City, @canUseStrength, $canFightTeamRocket, @canUseSurf"],
+				"visibility_rules": ["full_item", "tms"],
+				"chest_unopened_img": "images/chests/tm_hm_unopened.png",
+				"chest_opened_img": "images/chests/tm_hm_opened.png",
+				"item_count": 1
 			},
 			{
 				"name": "Blackglasses Guy",   

--- a/locations/Route35.json
+++ b/locations/Route35.json
@@ -14,7 +14,7 @@
 			},
 			{
 				"name": "Pick Up Kenya",
-				"visibility_rules": ["full_item"],
+				"visibility_rules": ["full_item", "tms"],
 				"hosted_item": "kenya"
 			},
 			{


### PR DESCRIPTION
Added two checks that are missing from the TMs flag:

* Kenya pick-up (the drop-off is already flagged correctly, but needs the pick-up to have been flagged before it shows as available)
* TM13 Snore in Dark Cave Blackthorn side (the bottom-left item)